### PR TITLE
Yocto experimental

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -10,8 +10,8 @@
   <remote fetch="git://github.com/koenkooi"  name="KODI"/>
   <remote fetch="git://github.com/streamitbv" name="streamit" />
     
-  <project remote="rockchip" revision="master" name="meta-rockchip" path="sources/meta-rockchip"/>
-  <project remote="rockchip" revision="master" name="meta-rockchip-extra" path="sources/meta-rockchip-extra"/>
+  <project remote="rockchip" revision="76951aa33a58271cb4533469ed489ed5e52f58c4" name="meta-rockchip" path="sources/meta-rockchip"/>
+  <project remote="rockchip" revision="c5d96a6124c9f17e7da158b9c228854dd5a353c9" name="meta-rockchip-extra" path="sources/meta-rockchip-extra"/>
  
   <project remote="streamit" revision="master" name="rkbin" path="rkbin"/>
 

--- a/master.xml
+++ b/master.xml
@@ -8,12 +8,14 @@
   <remote fetch="git://github.com/OSSystems" name="OSSystems"/>
   <remote fetch="git://github.com/meta-qt5"  name="QT5"/>
   <remote fetch="git://github.com/koenkooi"  name="KODI"/>
+  <remote fetch="git://github.com/streamitbv" name="streamit" />
     
   <project remote="rockchip" revision="master" name="meta-rockchip" path="sources/meta-rockchip"/>
   <project remote="rockchip" revision="master" name="meta-rockchip-extra" path="sources/meta-rockchip-extra"/>
  
-  <project remote="rockchip" revision="master" name="rkbin" path="rkbin"/>
-  <project remote="rockchip" revision="yocto" name="build" path="sources/base">
+  <project remote="streamit" revision="master" name="rkbin" path="rkbin"/>
+
+  <project remote="streamit" revision="yocto" name="build" path="sources/base">
         <copyfile dest="README" src="README"/>
         <copyfile dest="setup-environment" src="setup-environment"/>
   </project>
@@ -21,6 +23,7 @@
   <project remote="yocto" revision="master" name="poky" path="sources/poky"/>
   <project remote="oe" revision="master" name="meta-openembedded" path="sources/meta-openembedded"/>
   <project remote="QT5" revision="master" name="meta-qt5" path="sources/meta-qt5" />
-  <project remote="OSSystems" revision="master" name="meta-browser" path="sources/meta-browser" />
+  <project remote="streamit" revision="master" name="meta-streamit" path="sources/meta-streamit" />
+  <project remote="streamit" revision="chromium61" name="meta-crosswalk" path="sources/meta-crosswalk" />
  
   </manifest>


### PR DESCRIPTION
In order to avoid breaking changes in Rockchip meta layers, the default manifest can be updated to get a specific (last tested/working) revision. In addition we update the master manifest to include the Streamit BSP part, so that someone can switch to using master branch for the Rockchip meta layers.